### PR TITLE
Add 'future' to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ packaging==16.8
 pyparsing==2.2.0
 requests==2.13.0
 six==1.10.0
+future==0.16.0


### PR DESCRIPTION
Prevents ImportError: No module named builtins